### PR TITLE
Added Themed / Monochrome App icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
This PR adds support for Android 13+ Themed launcher app icon.

#### Example in Dark Theme + Custom Swatch

![ResizedImage_2024-01-28_11-11-31_1022](https://github.com/fumiama/copymanga/assets/57289288/04ac07d7-e537-490f-a001-d6f8538289b8)
