### PR TITLE
阅读器返回至评论区

### DIFF
--- a/app/src/main/java/top/fumiama/copymangaweb/activity/ViewMangaActivity.kt
+++ b/app/src/main/java/top/fumiama/copymangaweb/activity/ViewMangaActivity.kt
@@ -22,7 +22,6 @@ import top.fumiama.copymangaweb.R
 import top.fumiama.copymangaweb.activity.reader.ContinuousMangaAdapter
 import top.fumiama.copymangaweb.activity.reader.PagedMangaAdapter
 import top.fumiama.copymangaweb.activity.reader.ReaderOverlayController
-import top.fumiama.copymangaweb.activity.MainActivity.Companion.wm
 import top.fumiama.copymangaweb.activity.template.ToolsBoxActivity
 import top.fumiama.copymangaweb.databinding.ActivityViewmangaBinding
 import top.fumiama.copymangaweb.tool.PropertiesTools
@@ -57,7 +56,6 @@ class ViewMangaActivity : ToolsBoxActivity() {
     private var readerPrepared = false
     private var streamFinished = false
     private var streamDeclaredCount = 0
-    private var userRequestedExit = false
     private var backInvokedCallback: OnBackInvokedCallback? = null
     private val streamSeenUrls = LinkedHashSet<String>()
     private var pagedAdapter: PagedMangaAdapter? = null
@@ -357,7 +355,6 @@ class ViewMangaActivity : ToolsBoxActivity() {
     }
 
     private fun exitByUserRequest() {
-        userRequestedExit = true
         finishAfterTransition()
     }
 
@@ -692,7 +689,6 @@ class ViewMangaActivity : ToolsBoxActivity() {
         dialog?.dismiss()
         dialog = null
         mBinding.wcollector.destroy()
-        if (userRequestedExit && !dlZip2View) wm?.get()?.mBinding?.w?.goBack()
         if (streamUrl != null) streamChapterUrl = null
         if (va?.get() === this) va = null
         super.onDestroy()


### PR DESCRIPTION
改动：在阅读器返回，回到有章节评论的网页，再返回一次到漫画详情页

目前点击章节会直接跳转到阅读器，返回又直接回到详情页，导致每章评论区看不了